### PR TITLE
Added OpenAI support for docx with multiple pages

### DIFF
--- a/backend/app/api/api_utils.py
+++ b/backend/app/api/api_utils.py
@@ -62,4 +62,6 @@ async def process_file(file: UploadFile, file_extension: str, system_prompt: str
 
     clean_temp_storage(TEMP_STORAGE_DIR)
 
-    return markdown_content
+    cleaned_markdown_content = markdown_content.replace("**Evaluation Warning:** The document was created with Spire.Doc for Python.", "")
+
+    return cleaned_markdown_content

--- a/backend/app/utils/image_utils.py
+++ b/backend/app/utils/image_utils.py
@@ -15,13 +15,12 @@ def docx_to_images(file_path: str):
 
     image_streams = document.SaveImageToStreams(ImageType.Bitmap)
 
-    for image in image_streams:
-        image_name = f"img.png"
+    for page_num, image in enumerate(image_streams):
+        image_name = f"img{page_num}.png"
         image_path = os.path.join(TEMP_STORAGE_DIR, image_name)
         with open(image_path,'wb') as image_file:
             image_file.write(image.ToArray())
         image_paths.append(image_path)
-        break
 
     document.Close()
     


### PR DESCRIPTION
Added multiple page processing for docx (OpenAI).

Cleaned markdown content by removing the evaluation warning comes from Spire Doc. But that warning affects the accuracy of initial page separation.